### PR TITLE
fix: Handle silently failing run yt-dlp errors and add retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,14 +2731,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stream_digest"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "tokio",
-]
-
-[[package]]
 name = "stream_pulse"
 version = "0.1.0"
 dependencies = [

--- a/crates/stream_pulse/src/lib/process_stream.rs
+++ b/crates/stream_pulse/src/lib/process_stream.rs
@@ -107,7 +107,10 @@ fn handle_stream_audio(
 
     // Skip download if .mp3 already exists
     if !audio_mp3_path.exists() {
-        ytdlp.download_audio(&youtube_stream, &audio_base_path)?;
+        if let Err(e) = ytdlp.download_audio(&youtube_stream, &audio_base_path) {
+            tracing::error!(error = ?e, "Failed to download video");
+            bail!("Failed to download video: {:?}", e);
+        };
     } else {
         tracing::debug!("Audio already exists at {:?}", audio_mp3_path);
     }


### PR DESCRIPTION
Fixes #28 

The issue was largely with `yt-dlp` failing

Additional Changes
 
- Tests that verify that the path to any provided `cookies.txt` file is valid
- Add retry logic for `run_yt_dlp`